### PR TITLE
[rapidboard-support]: Added support for RapidBoard urls

### DIFF
--- a/jira_api.py
+++ b/jira_api.py
@@ -1,7 +1,8 @@
-from datetime import datetime
 import json
 import requests
+from datetime import datetime
 from decouple import config
+from urllib.parse import parse_qs
 
 
 class JiraClient:
@@ -83,7 +84,10 @@ def extract_task_code(external_permalink):
     task_code = external_permalink.split('/')[-1]
 
     if '?' in task_code:
-        task_code = task_code.split('?')[0]
+        if 'selectedIssue' in task_code:
+            task_code = parse_qs(external_permalink)['selectedIssue'][0]
+        else:
+            task_code = task_code.split('?')[0]
 
     if '#' in task_code:
         task_code = task_code.replace('#', '')

--- a/load_hours.py
+++ b/load_hours.py
@@ -29,9 +29,6 @@ for entry in time_entries:
     notes = format_notes(entry['notes'])
 
     if 'external_reference' in entry:
-        if not entry.get('external_reference'):
-            continue
-
         task_code = extract_task_code(
             entry['external_reference']['permalink'])
 

--- a/load_hours.py
+++ b/load_hours.py
@@ -29,6 +29,9 @@ for entry in time_entries:
     notes = format_notes(entry['notes'])
 
     if 'external_reference' in entry:
+        if not entry.get('external_reference'):
+            continue
+
         task_code = extract_task_code(
             entry['external_reference']['permalink'])
 


### PR DESCRIPTION
#2 
When we add the time tracking from the RapidBoard visualization, it uses an URL like this:
```
https://<domain>.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=<issue_id>&assignee=luiz
```

It was added a urlparser to get all the params from the url, so we could select just the one that we needed, which is `selectedIssue`.