### PR TITLE
Fixes comments payload on adding worklog request

### DIFF
--- a/jira_api.py
+++ b/jira_api.py
@@ -54,13 +54,7 @@ class JiraClient:
 
 def format_notes(entry_notes):
     notes_row = entry_notes.split('\n')
-    notes = []
-    for row in notes_row:
-        note = {
-            "text": row,
-            "type": "text"
-        }
-        notes.append(note)
+    notes = [{"text": row, "type": "text"} for row in notes_row]
     return notes
 
 

--- a/jira_api.py
+++ b/jira_api.py
@@ -32,12 +32,7 @@ class JiraClient:
                 "content": [
                     {
                         "type": "paragraph",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": comments
-                            }
-                        ]
+                        "content": comments
                     }
                 ]
             }
@@ -59,7 +54,14 @@ class JiraClient:
 
 def format_notes(entry_notes):
     notes_row = entry_notes.split('\n')
-    return notes_row[1:len(notes_row)] if len(notes_row) > 1 else ""
+    notes = []
+    for row in notes_row:
+        note = {
+            "text": row,
+            "type": "text"
+        }
+        notes.append(note)
+    return notes
 
 
 def format_date(entry_date):


### PR DESCRIPTION
Now we are going to pass the complete comment from Harvest, including the task number and description. We are splitting the harvest comment into lines and send them in a list for worklog comment paragraph.