### PR TITLE
Keep track of the last day it ran

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env/
 .env
 .DS_Store
+.aux

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env/
 .DS_Store
 .aux
 __pycache__
+.aux_days

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ env/
 .aux
 __pycache__
 .aux_days
+bin/
+include/
+lib/
+share/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ env/
 .env
 .DS_Store
 .aux
+__pycache__

--- a/hours_calendar.py
+++ b/hours_calendar.py
@@ -1,0 +1,31 @@
+from cprint import cprint
+from datetime import datetime, date, timedelta
+
+
+LAST_DAY_FILE = '.aux_days'
+DATE_FORMAT = '%Y/%m/%d'
+
+
+def get_date_range():
+    try:
+        with open(LAST_DAY_FILE, 'r') as f:
+            raw_last_day = f.read().strip()
+            last_day = datetime.strptime(raw_last_day, DATE_FORMAT).date()
+    except FileNotFoundError:
+        cprint.warn(f"You don't have a last day configured yet.")
+        cprint.warn(f"Please input the start date:\n")
+        last_day = None
+        while not last_day:
+            raw_last_day = input(f"Date as {DATE_FORMAT}: ").strip()
+            try:
+                last_day = datetime.strptime(raw_last_day, DATE_FORMAT).date()
+            except ValueError:
+                cprint.err(f"Invalid date format. Please try again...")
+
+    date_to = date.today() - timedelta(days=1)
+    return last_day, date_to
+
+
+def update_last_day(new_last_day):
+    with open(LAST_DAY_FILE, 'w') as f:
+        f.write(new_last_day.strftime(DATE_FORMAT))

--- a/load_hours.py
+++ b/load_hours.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime, timedelta
 from decouple import config
 from harvest_api import HarvestClient
 from jira_api import (
@@ -10,14 +10,26 @@ from jira_api import (
 harvest_client = HarvestClient()
 jira_client = JiraClient()
 
-date_from = date.today().isoformat()
-date_to = date.today().isoformat()
+# Track the last day it runned
+with open('.aux', 'r') as f:
+    last_day = f.read()
+    if not last_day:
+        last_day = date.today()
+
+if isinstance(last_day, str):
+    last_day = datetime.strptime(last_day, '%d/%m/%Y').date()
+
+date_from = last_day.date()
+date_to = date.today() - timedelta(days=1)
+
+with open('.aux', 'w+') as f:
+    f.write(date_to)
 
 harvest_filters = {
     'user_id': config('HARVEST_USER_ID'),
     'client_id': config('HARVEST_CLIENT_ID'),
-    'from': date_from,
-    'to': date_to
+    'from': date_from.isoformat(),
+    'to': date_to.isoformat()
 }
 
 time_entries = harvest_client.filter_resource(

--- a/load_hours.py
+++ b/load_hours.py
@@ -1,29 +1,22 @@
-from datetime import date, datetime, timedelta
+from cprint import cprint
 from decouple import config
 from harvest_api import HarvestClient
 from jira_api import (
     format_hours, format_notes, extract_task_code, format_date,
     JiraClient, get_project_bucket, is_new_worklog
 )
+from hours_calendar import get_date_range, update_last_day, DATE_FORMAT
 
 
 harvest_client = HarvestClient()
 jira_client = JiraClient()
 
 # Track the last day it ran
-with open('.aux', 'r') as f:
-    last_day = f.read()
-    if not last_day:
-        last_day = date.today()
 
-if isinstance(last_day, str):
-    last_day = datetime.strptime(last_day, '%d/%m/%Y').date()
 
-date_from = last_day
-date_to = date.today() - timedelta(days=1)
+date_from, date_to = get_date_range()
 
-with open('.aux', 'w+') as f:
-    f.write(date_to.strftime('%d/%m/%Y'))
+cprint.info("Updating worklog from {date_from.strptime(DATE_FORMAT)} to {date_to.strptime(DATE_FORMAT}\n")
 
 harvest_filters = {
     'user_id': config('HARVEST_USER_ID'),
@@ -64,3 +57,5 @@ for entry in time_entries:
                     print(f"{project_bucket} - Error {status_code} when creating worklog {entry_hours} on {entry_date} for task {task_code}")
             else:
                 print(f"Worklog for {task_code} already exists at {entry_date} during {entry_hours}")
+
+update_last_day(date_to)

--- a/load_hours.py
+++ b/load_hours.py
@@ -8,6 +8,11 @@ from jira_api import (
 from hours_calendar import get_date_range, update_last_day, DATE_FORMAT
 
 
+def format_harvest_url(entry_date):
+    split_date = entry_date.split('-')
+    return f"https://labcodes.harvestapp.com/time/day/{split_date[0]}/{split_date[1]}/{split_date[2][:2]}/"
+
+
 harvest_client = HarvestClient()
 jira_client = JiraClient()
 
@@ -38,7 +43,7 @@ for entry in time_entries:
             task_code = extract_task_code(
                 entry['external_reference']['permalink'])
         except TypeError:
-            cprint.warn(f"Task {entry['id']} from {entry_date} has no permalink and was skipped. Make sure this task really should have no permalink.")
+            cprint.warn(f"Task {entry['id']} from {entry_date} has no permalink and was skipped. Make sure this task really should have no permalink: {format_harvest_url(entry_date)}")
             continue
 
         if task_code != 'SA-15876':  # We are skipping scrum task since we are adding worklog manually

--- a/load_hours.py
+++ b/load_hours.py
@@ -10,7 +10,7 @@ from jira_api import (
 harvest_client = HarvestClient()
 jira_client = JiraClient()
 
-# Track the last day it runned
+# Track the last day it ran
 with open('.aux', 'r') as f:
     last_day = f.read()
     if not last_day:

--- a/load_hours.py
+++ b/load_hours.py
@@ -19,11 +19,11 @@ with open('.aux', 'r') as f:
 if isinstance(last_day, str):
     last_day = datetime.strptime(last_day, '%d/%m/%Y').date()
 
-date_from = last_day.date()
+date_from = last_day
 date_to = date.today() - timedelta(days=1)
 
 with open('.aux', 'w+') as f:
-    f.write(date_to)
+    f.write(date_to.strftime('%d/%m/%Y'))
 
 harvest_filters = {
     'user_id': config('HARVEST_USER_ID'),
@@ -59,8 +59,8 @@ for entry in time_entries:
                 status_code = response.status_code
 
                 if response.status_code == 201:
-                    print(f"{project_bucket} - Worklog {entry_hours} created on {entry_date}")
+                    print(f"{project_bucket} - Worklog {entry_hours} created on {entry_date} for task {task_code}")
                 else:
-                    print(f"{project_bucket} - Error {status_code} when creating worklog {entry_hours} on {entry_date}")
+                    print(f"{project_bucket} - Error {status_code} when creating worklog {entry_hours} on {entry_date} for task {task_code}")
             else:
-                print(f"Worklog for {task} already exists at {entry_date} during {entry_hours}")
+                print(f"Worklog for {task_code} already exists at {entry_date} during {entry_hours}")

--- a/load_hours.py
+++ b/load_hours.py
@@ -11,9 +11,6 @@ from hours_calendar import get_date_range, update_last_day, DATE_FORMAT
 harvest_client = HarvestClient()
 jira_client = JiraClient()
 
-# Track the last day it ran
-
-
 date_from, date_to = get_date_range()
 
 s_start, s_end = date_from.isoformat(), date_to.isoformat()
@@ -34,11 +31,15 @@ jira_worklogs = {}
 for entry in time_entries:
     entry_date = format_date(entry['created_at'])
     entry_hours = format_hours(entry['hours'])
-    notes = format_notes(entry['notes'])
+    notes = format_notes(entry.get('notes') or '')
 
     if 'external_reference' in entry:
-        task_code = extract_task_code(
-            entry['external_reference']['permalink'])
+        try:
+            task_code = extract_task_code(
+                entry['external_reference']['permalink'])
+        except TypeError:
+            cprint.warn(f"Task {entry['id']} from {entry_date} has no permalink and was skipped. Make sure this task really should have no permalink.")
+            continue
 
         if task_code != 'SA-15876':  # We are skipping scrum task since we are adding worklog manually
             project_bucket = get_project_bucket(task_code)

--- a/load_hours.py
+++ b/load_hours.py
@@ -16,7 +16,8 @@ jira_client = JiraClient()
 
 date_from, date_to = get_date_range()
 
-cprint.info("Updating worklog from {date_from.strptime(DATE_FORMAT)} to {date_to.strptime(DATE_FORMAT}\n")
+s_start, s_end = date_from.isoformat(), date_to.isoformat()
+cprint.info(f"Updating worklog from {s_start} to {s_end}\n")
 
 harvest_filters = {
     'user_id': config('HARVEST_USER_ID'),
@@ -52,10 +53,10 @@ for entry in time_entries:
                 status_code = response.status_code
 
                 if response.status_code == 201:
-                    print(f"{project_bucket} - Worklog {entry_hours} created on {entry_date} for task {task_code}")
+                    cprint.ok(f"{project_bucket} - Worklog {entry_hours} created on {entry_date} for task {task_code}")
                 else:
-                    print(f"{project_bucket} - Error {status_code} when creating worklog {entry_hours} on {entry_date} for task {task_code}")
+                    cprint.err(f"{project_bucket} - Error {status_code} when creating worklog {entry_hours} on {entry_date} for task {task_code}")
             else:
-                print(f"Worklog for {task_code} already exists at {entry_date} during {entry_hours}")
+                cprint.info(f"Worklog for {task_code} already exists at {entry_date} during {entry_hours}")
 
 update_last_day(date_to)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ six==1.11.0
 tapioca-harvest==2.0
 tapioca-wrapper==0.5.3
 urllib3==1.24.1
+cprint==1.1


### PR DESCRIPTION
After each week it was getting confusing which day I ran the script. The solution here is to create a file `.aux` that will keep tracking the last day it ran.

Another feature is to run from `date_to` a day before today to avoid repeated worklog on the same task, if we are not finished yet.