### PR TITLE
Use .get() when accessing Jira Worklog author email address

### DIFF
--- a/jira_api.py
+++ b/jira_api.py
@@ -123,7 +123,7 @@ def is_new_worklog(worklog, entry_date, entry_hours):
     format_date_tz = lambda x: datetime.strptime(x, '%Y-%m-%dT%H:%M:%S.%f%z')
     exists = [
         wk for wk in worklog
-        if wk['author']['emailAddress'] == config('JIRA_USERNAME') and
+        if wk['author'].get('emailAddress') == config('JIRA_USERNAME') and
         wk['timeSpent'] == entry_hours and
         format_date_tz(entry_date) == format_date_tz(wk['started'])
     ]


### PR DESCRIPTION
**Description of your solution:**
Sometimes the jira worklog author object doesn't contain the `emailAddress` field. So we're using `.get` to avoid `KeyError`.