### PR TITLE
Find Jira ticket code from notes text

### DIFF
--- a/jira_api.py
+++ b/jira_api.py
@@ -1,8 +1,11 @@
 import json
 import requests
+import re
 from datetime import datetime
 from decouple import config
 from urllib.parse import parse_qs
+
+JIRA_TICKET_REGEX = r'([A-Z]{1,10}-\d+)'
 
 
 class JiraClient:
@@ -108,6 +111,19 @@ def extract_task_code(external_permalink):
     if '#' in task_code:
         task_code = task_code.replace('#', '')
 
+    return task_code
+
+
+def validate_task_code(task_code):
+    match = re.search(JIRA_TICKET_REGEX, task_code, flags=re.IGNORECASE)
+    return True if match else False
+
+
+def extract_task_code_from_text(note):
+    task_code = ''
+    match = re.search(JIRA_TICKET_REGEX, note, flags=re.IGNORECASE)
+    if match:
+        task_code = match.group()
     return task_code
 
 

--- a/load_hours.py
+++ b/load_hours.py
@@ -2,8 +2,8 @@ from cprint import cprint
 from decouple import config
 from harvest_api import HarvestClient
 from jira_api import (
-    format_hours, format_notes, extract_task_code, format_date,
-    JiraClient, is_new_worklog
+    format_hours, format_notes, validate_task_code, extract_task_code,
+    extract_task_code_from_text, format_date, JiraClient, is_new_worklog
 )
 from hours_calendar import get_date_range, update_last_day, DATE_FORMAT
 
@@ -42,6 +42,9 @@ for entry in time_entries:
         try:
             task_code = extract_task_code(
                 entry['external_reference']['permalink'])
+            is_valid = validate_task_code(task_code)
+            if not is_valid:
+                task_code = extract_task_code_from_text(entry['notes'])
         except TypeError:
             cprint.warn(f"Task {entry['id']} from {entry_date} has no permalink and was skipped. Make sure this task really should have no permalink: {format_harvest_url(entry_date)}")
             continue


### PR DESCRIPTION
For some reason sometimes we were not getting the task code from the URL, but we could find it on the ticket's notes. This PR will validate the task_code obtained in the URL, if it is not valid, it will get it from the Notes field.